### PR TITLE
Add `readme` and `contents` from the Contents API

### DIFF
--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -403,3 +403,15 @@
             "hub.callback" callback}
            (when-let [secret (:secret options)]
              {"hub.secret" secret}))})))
+
+;; ## Repo Contents API
+
+(defn readme
+  "Get the preferred README for a repository."
+  [user repo options]
+  (api-call :get "repos/%s/%s/readme" [user repo] options))
+
+(defn contents
+  "Get the contents of any file or directory in a repository."
+  [user repo path options]
+  (api-call :get "repos/%s/%s/contents/%s" [user repo path] options))


### PR DESCRIPTION
http://developer.github.com/v3/repos/contents/

I begin adding `archive-link` too, but it didn't play well with `api-call` since it doesn't return json. 

Here's my partial impl incase anyone wants to pick it up from here:

```
(defn archive-link
  "Get a URL to download a tarball or zipball archive for a repository.
     archive-format -- tarball or zipball
     git-ref        -- a valid git ref (e.g. master)"
  ([user repo archive-format git-ref options]
   (api-call :get "repos/%s/%s/%s/%s" [user repo archive-format git-ref] options)))
```
