### PR TITLE
add the three routes from the contents API

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,4 +6,5 @@
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [clj-http "0.4.0"]
                  [cheshire "4.0.0"]
-                 [com.cemerick/url "0.0.6"]])
+                 [com.cemerick/url "0.0.6"]
+                 [org.clojure/data.codec "0.1.0"]])


### PR DESCRIPTION
This patch adds the three missing routes from the Content API. It adds a utility method to decode the automatically the base64 encoded content and a lower level `raw-api-call` which does no further work after creating the base request (to handle non-JSON response).
