### PR TITLE
Adds support for conditional requests and new way of checking rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ If an API function has no options and authentication would have no uses for that
 
 Authentication is supported by Github user authentication `:auth <username:password>` as demonstrated above, or by oauth or oauth2.  For oauth add `:oauth-token <token>` to the options map.  Likewise, for oauth2, include `:client-id <client_id> :client-token <client_token>` in the options map.
 
-You can access useful information returned by the API such as current rate limits, etags, etc. by checking the metadata of the response. You can then use this to perform conditional requests against the API. If the data has not changed, the keyword `:tentacles.core/not-modified` will be returned. This does not consume any API call quota.
+You can access useful information returned by the API such as current
+rate limits, etags, etc. by checking the response with `core/api-meta`. You can then use this to perform conditional requests against the API. If the data has not changed, the keyword `:tentacles.core/not-modified` will be returned. This does not consume any API call quota.
 
 ```clojure
-user> (meta (repos/readme "Raynes" "tentacles" {}))
+user> (core/api-meta (repos/readme "Raynes" "tentacles" {}))
 {:links {nil nil}, :etag "\"f1f3cfabbf0f98e0bbaa7aa424f92e75\"", :last-modified "Mon, 28 Jan 2013 21:13:48 GMT", :call-limit 60, :call-remaining 59}
 
 user> (repos/readme "Raynes" "tentacles" {:etag "\"f1f3cfabbf0f98e0bbaa7aa424f92e75\""})

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -6,8 +6,7 @@
    (is (= (:status (core/safe-parse {:status 403}))
      403)))
 
-(deftest rate-limit-details-are-propagated-when-defined
-   (is (contains? (core/safe-parse {:status 200 :X-RateLimit-Limit 20 :headers {"content-type" ""}}) :X-RateLimit-Limit)))
-
-(deftest rate-limit-details-are-ignored-when-undefined
-   (is (not (contains? (core/safe-parse {:status 200 :headers {"content-type" ""}}) :X-RateLimit-Limit))))
+(deftest rate-limit-details-are-propagated
+  (is (= 60 (:call-limit (core/api-meta
+                          (core/safe-parse {:status 200 :headers {"x-ratelimit-limit" "60"
+                                                                  "content-type" ""}}))))))


### PR DESCRIPTION
This patch changed adds support for making conditional HTTP requests to the API, and introduces a new way to check rate-limits. I switched from merging the keys directly into the response to supplying them under a certain meta key because the merge policy was problematic for the API routes that returned vectors and not a map.
When returning a lazy seq, metadata cannot be maintained on the response itself so this patch adds on each object of the seq the metadata that corresponds to the request with which it was received.
