### PR TITLE
Bump version on clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This library is the successor to my old [clj-github](https://github.com/Raynes/c
 
 ## Usage
 
-This is on clojars, of course. Just add `[tentacles "0.2.4"]` to your `:dependencies` in your project.clj file.
+This is on clojars, of course. Just add `[tentacles "0.2.5"]` to your `:dependencies` in your project.clj file.
 
 ### CODE!
 


### PR DESCRIPTION
Readme is little bit inconsistent (especially with `api-meta`). 
This commit is getting rid of it.
