### PR TITLE
enable options for tentacles.events/events

### DIFF
--- a/src/tentacles/events.clj
+++ b/src/tentacles/events.clj
@@ -4,8 +4,8 @@
 
 (defn events
   "List public events."
-  []
-  (api-call :get "events" nil nil))
+  [& [options]]
+  (api-call :get "events" nil options))
 
 (defn repo-events
   "List repository events."


### PR DESCRIPTION
API for public events should be able to receive options like :page, :oauth-token, etc.
