### PR TITLE
Add poll-interval to metadata. (From "X-Poll-Interval" events header.)

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -33,10 +33,13 @@
 
 (defn extract-useful-meta
   [h]
-  (let [{:strs [etag last-modified x-ratelimit-limit x-ratelimit-remaining]} h]
+  (let [{:strs [etag last-modified x-ratelimit-limit x-ratelimit-remaining
+                x-poll-interval]}
+        h]
     {:etag etag :last-modified last-modified
      :call-limit (when x-ratelimit-limit (Long/parseLong x-ratelimit-limit))
-     :call-remaining (when x-ratelimit-remaining (Long/parseLong x-ratelimit-remaining))}))
+     :call-remaining (when x-ratelimit-remaining (Long/parseLong x-ratelimit-remaining))
+     :poll-interval (when x-poll-interval (Long/parseLong x-poll-interval))}))
 
 (defn api-meta
   [obj]

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -10,3 +10,9 @@
   (is (= 60 (:call-limit (core/api-meta
                           (core/safe-parse {:status 200 :headers {"x-ratelimit-limit" "60"
                                                                   "content-type" ""}}))))))
+
+(deftest poll-limit-details-are-propagated
+  (is (= 61 (:poll-interval (core/api-meta
+                             (core/safe-parse {:status 200
+                                               :headers {"x-poll-interval" "61"
+                                                         "content-type" ""}}))))))


### PR DESCRIPTION
From the [Events section](http://developer.github.com/v3/activity/events/) of GitHub's API:

> There is also an “X-Poll-Interval” header that specifies how often (in seconds) you are allowed to poll. In times of high server load, the time may increase. Please obey the header.
