### PR TITLE
When requesting :all_pages, result has metadata of the first response.

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -121,7 +121,7 @@
                             (if (and all-pages? (-> resp meta :links :next))
                               (let [new-req (update-req req (-> resp meta :links :next))]
                                 (with-meta (lazy-cat resp (exec-request new-req))
-                                  (meta resp)))
+                                           (meta resp)))
                               resp)))]
        (exec-request req))))
 


### PR DESCRIPTION
Example:

``` clojure
user> (require '[tentacles.events :as events])
nil

user> (def es (events/events {:all_pages true}))
#'user/es

user> (meta es)
{:links {:next "https://api.github.com/events?page=2"},
 :api-meta
 {:etag "...",
  :last-modified "...",
  :call-limit 60,
  :call-remaining 58,
  :poll-interval 60}}
```

(The slight inefficiency of calling with-meta with each call to lazy-cat — then not using most metadata — should be insignificant.)
