### PR TITLE
added support for environ to manage github auth locally

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,9 @@
   :url "https://github.com/Raynes/tentacles"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
+  :dependencies [[org.clojure/clojure "1.5.1"]
                  [clj-http "0.4.0"]
                  [cheshire "4.0.0"]
                  [com.cemerick/url "0.0.6"]
-                 [org.clojure/data.codec "0.1.0"]])
+                 [org.clojure/data.codec "0.1.0"]
+                 [environ "0.4.0"]])

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -133,7 +133,12 @@
            req (make-request method end-point positional query)]
        (http/request req))))
 
-(defn rate-limit 
+(defn environ-auth
+  "Lookup :gh-username and :gh-password in environ (~/.lein/profiles.clj or .lein-env) and return a string auth.
+   Usage: (users/me {:auth (environ-auth)})"
+  (str (:gh-username env ) ":" (:gh-password env)))
+
+(defn rate-limit
   ([] (api-call :get "rate_limit"))
   ([opts] (api-call :get "rate_limit" nil opts)))
 


### PR DESCRIPTION
[Environ](https://github.com/weavejester/environ) simplifies management of env vars as data, I think, and avoids hardcoding basic auth in api clients. I'd like to push this as a best practice.

The following api pulls :gh-username and :gh-password from ~/.lein/profiles.clj or .lein-env map and returns a string username:password, as requiured by tentacles.

`(users/me {:auth (environ-auth)}`

I also updated the clojure version.
