### PR TITLE
User agent can be set on requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ user> (repos/readme "Raynes" "tentacles" {:if-modified-since "Mon, 28 Jan 2013 2
 :tentacles.core/not-modified
 ```
 
+Similarly, you can set an User-Agent to make your requests more friendly and identifiable.
+
+```clojure
+user> (repos/readme "Raynes" "tentacles" {:user-agent "MyPhoneApp"})
+```
+
 The Github API is massive and great. I can't demonstrate every API call. Everything is generally just as easy as the above examples, and I'm working hard to document things as well as possible, so go explore!
 
 Here are some lovely [Marginalia docs](http://raynes.github.com/tentacles). I also wrote a demonstrational [blog post](http://blog.raynes.me/blog/2011/12/02/waving-our-tentacles/) about Tentacles that I intend to keep updated with future releases.

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -83,8 +83,8 @@
   (str url (apply format end-point (map #(URLEncoder/encode (str %) "UTF-8") positional))))
 
 (defn make-request [method end-point positional
-                    {:strs [auth throw_exceptions follow_redirects
-                            accept oauth_token etag if_modified_since]
+                    {:strs [auth throw_exceptions follow_redirects accept
+                            oauth_token etag if_modified_since user_agent]
                      :or {follow_redirects true throw_exceptions false}
                      :as query}]
   (let [req (merge-with merge
@@ -99,9 +99,11 @@
                           {:headers {"Authorization" (str "token " oauth_token)}})
                         (when etag
                           {:headers {"if-None-Match" etag}})
+                        (when user_agent
+                          {:headers {"User-Agent" user_agent}})
                         (when if_modified_since
                           {:headers {"if-Modified-Since" if_modified_since}}))
-        proper-query (dissoc query "auth" "oauth_token" "all_pages" "accept")
+        proper-query (dissoc query "auth" "oauth_token" "all_pages" "accept" "user_agent")
         req (if (#{:post :put :delete} method)
               (assoc req :body (json/generate-string (or (proper-query "raw") proper-query)))
               (assoc req :query-params proper-query))]

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -2,9 +2,15 @@
   (:use clojure.test)
   (:require [tentacles.core :as core]))
 
+(deftest request-contains-user-agent
+  (let [request (core/make-request :get "test" nil {"user_agent" "Mozilla"})]
+    (do (is (empty?    (:query-params request)))
+      (is (contains? (:headers request) "User-Agent"))
+      (is (= (get (:headers request) "User-Agent") "Mozilla")))))
+
 (deftest hitting-rate-limit-is-propagated
-   (is (= (:status (core/safe-parse {:status 403}))
-     403)))
+  (is (= (:status (core/safe-parse {:status 403}))
+         403)))
 
 (deftest rate-limit-details-are-propagated
   (is (= 60 (:call-limit (core/api-meta


### PR DESCRIPTION
This allows users to make identifiable requests using an user agent.

In addition to that, I added a very simple test checking requests are created properly and 2 lines on the README.

Thanks @JeffreyPalmer for reporting the issue https://github.com/Raynes/tentacles/issues/40
