### PR TITLE
Code search API support

### DIFF
--- a/src/tentacles/search.clj
+++ b/src/tentacles/search.clj
@@ -30,3 +30,24 @@
   (let [results (api-call :get "/legacy/user/search/%s" [keyword] options)]
     (or (:users results)
         results)))
+
+(defn search-code
+  "Find file contents via various criteria. This method returns up to 100
+  results per page.
+  Parameters are:
+    q: string - The search terms. I.e: 'defn mymethod in:file language:cljj'
+    sort: string (optional) - Sort field, defaults to best match,
+    order: string (optional) - Sort order if sort parameter is provided.
+
+  i.e: (search/search-code \"addClass in:file language:js repo:jquery/jquery\")
+
+  More details about the search terms syntax in:
+  http://developer.github.com/v3/search/#search-code"
+  [query & [sort order options]]
+  (let [results (api-call :get "search/code" nil
+                          (assoc options
+                                 :q query
+                                 :sort sort
+                                 :order order))]
+    (or (:code results)
+        results)))


### PR DESCRIPTION
@Raynes this does not work yet. I added it as per https://github.com/Raynes/tentacles/issues/31

My two guesses are that, either the string sanitizer clj-http uses, or the content/type of our requests is flawed for non legacy versions of Github's API.

Sanitized version:

``` clojure
user=> (search/search-code "q=addClass+in:file+language:js+repo:jquery/jquery")
{:trace-redirects ["https://api.github.com/search/code?q%3DaddClass%2Bin%3Afile%2Blanguage%3Ajs%2Brepo%3Ajquery%2Fjquery"], :status 422, :headers {"access-control-allow-origin" "*", "server" "GitHub.com", "x-ratelimit-reset" "1387152694", "content-type" "application/json; charset=utf-8", "x-github-request-id" "532EFA28:218B:5F42FD5:52AE44F9", "date" "Mon, 16 Dec 2013 00:10:34 GMT", "x-ratelimit-remaining" "4", "cache-control" "no-cache", "status" "422 Unprocessable Entity", "x-content-type-options" "nosniff", "x-ratelimit-limit" "5", "access-control-expose-headers" "ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval", "x-github-media-type" "github.beta; format=json", "content-length" "153", "connection" "close", "access-control-allow-credentials" "true"}, :body {:message "Validation Failed", :documentation_url "http://developer.github.com/v3/search", :errors [{:resource "Search", :field "q", :code "missing"}]}}
```

core/api-call version (non-sanitized parameters)

``` clojure
user=> (core/api-call :get "search/code?q=addClass+in:file+language:js+repo:jquery/jquery")
{:trace-redirects ["https://api.github.com/search/code?q=addClass+in:file+language:js+repo:jquery/jquery"], :status 422, :headers {"access-control-allow-origin" "*", "server" "GitHub.com", "x-ratelimit-reset" "1387152613", "content-type" "application/json; charset=utf-8", "x-github-request-id" "532EFA28:218C:49A4E8F:52AE44B8", "date" "Mon, 16 Dec 2013 00:09:29 GMT", "x-ratelimit-remaining" "2", "cache-control" "no-cache", "status" "422 Unprocessable Entity", "x-content-type-options" "nosniff", "x-ratelimit-limit" "5", "access-control-expose-headers" "ETag, Link, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval", "x-github-media-type" "github.beta; format=json", "content-length" "153", "connection" "close", "access-control-allow-credentials" "true"}, :body {:message "Validation Failed", :documentation_url "http://developer.github.com/v3/search", :errors [{:resource "Search", :field "q", :code "missing"}]}}
```

It's like github ignores the parameters on the URL, but if you copy-paste the latter url in the browser, it'll display the proper result. 

Your thoughts?
