### PR TITLE
Correct handling of parents when creating a commit

### DIFF
--- a/src/tentacles/data.clj
+++ b/src/tentacles/data.clj
@@ -45,8 +45,7 @@
   (api-call :post "repos/%s/%s/git/commits" [user repo]
             (assoc options
               :message message
-              :tree tree
-              :parents parents)))
+              :tree tree)))
 
 ;; ## References
 


### PR DESCRIPTION
I got the following exception and stack trace while attempting to create a commit using tentacles:

```
com.fasterxml.jackson.core.JsonGenerationException: Cannot JSON encode object of class: class clojure.core$parents: clojure.core$parents@5414c36d
    at cheshire.generate$generate.invoke(generate.clj:147)
    at cheshire.generate$generate.invoke(generate.clj:119)
    at cheshire.core$generate_string.invoke(core.clj:32)
    at cheshire.core$generate_string.invoke(core.clj:19)
    at tentacles.core$make_request.invoke(core.clj:81)
    at tentacles.core$api_call.invoke(core.clj:91)
    at tentacles.data$create_commit.invoke(data.clj:46)
```

We're trying to encode the Clojure `parents` function when we actually need to leave the `:parents` key alone in the options (since the user will have already provided it).
