### PR TITLE
use :oauth-token instead of :auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Default options can be specified via `with-defaults`.
 
 If an API function has no options and authentication would have no uses for that particular call, the options map is not a parameter at all. For API calls that can do different things based on whether or not you are authenticated but authentication is not **required**, then the options map will be an optional argument. For API calls that require authentication to function at all, the options map is a required argument. Any data that is required by an API call is a positional argument to the API functions. The options map only ever contains authentication info and/or optional input.
 
-Authentication is supported by Github user authentication `:auth <username:password>` as demonstrated above, or by oauth or oauth2.  For oauth add `:oauth-token <token>` to the options map.  Likewise, for oauth2, include `:client-id <client_id> :client-token <client_token>` in the options map.
+Authentication is supported by Github user authentication `:auth <username:password>` as demonstrated above, or by oauth or oauth2.  For oauth use `:oauth-token <token>` instead of `:auth` in the options map.  Likewise, for oauth2, include `:client-id <client_id> :client-token <client_token>` in the options map.
 
 You can access useful information returned by the API such as current
 rate limits, etags, etc. by checking the response with `core/api-meta`. You can then use this to perform conditional requests against the API. If the data has not changed, the keyword `:tentacles.core/not-modified` will be returned. This does not consume any API call quota.


### PR DESCRIPTION
The way the README is currently written made it sound like you just put :oauth-token in to the options map _in addition to_ :auth. When you add it, the header that gets put into the request is

```
>> Authorization: Basic asfdhjkfshjdfsdhjsfhdja897243879487943=
```

So it's still trying to do basic auth with the username/password. You really need to use :oauth-token _instead_ of :auth. When you replace it, the header that gets put into the request is

```
>> Authorization: token 87934589534980dgsflnjkldfgsfgsfd
```

For me this was a "Personal access token" created from the [Applications Settings](https://github.com/settings/applications) page.
