### PR TITLE
Add support for user teams

### DIFF
--- a/src/tentacles/users.clj
+++ b/src/tentacles/users.clj
@@ -114,3 +114,8 @@
   "Delete a public key."
   [id options]
   (no-content? (api-call :delete "user/keys/%s" [id] options)))
+
+(defn my-teams
+  "List the currently authenticated user's teams across all organizations"
+  [& [options]]
+  (api-call :get "user/teams" nil options))


### PR DESCRIPTION
This is just a quick change to add support to the user/teams resource:

https://developer.github.com/v3/orgs/teams/#list-user-teams

This offers a richer API than the similar /orgs/:org/teams resource.

Thanks
