### PR TITLE
Removed special casing of HTTP headers and request options

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "0.4.0"]
+                 [clj-http "1.0.0"]
                  [cheshire "4.0.0"]
                  [com.cemerick/url "0.0.6"]
                  [org.clojure/data.codec "0.1.0"]

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -96,7 +96,7 @@
   ([method end-point positional] (api-call method end-point positional nil))
   ([method end-point positional query]
      (let [query (query-map query)
-           all-pages? (*all-pages*)
+           all-pages? *all-pages*
            req (make-request method end-point positional query)
            exec-request-one (fn exec-request-one [req]
                               (safe-parse (http/request req)))

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -18,7 +18,7 @@
 
 (defn parse-json
   "Same as json/parse-string but handles nil gracefully."
-  [s] (when s (json/parse-string s true)))
+  [s] (when s (json/parse-string s (fn [k] (keyword (.replace (name k) "_" "-"))))))
 
 (defn parse-link [link]
   (let [[_ url] (re-find #"<(.*)>" link)

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -133,3 +133,7 @@
 (defmacro with-defaults [options & body]
  `(binding [defaults ~options]
     ~@body))
+
+(defmacro with-all-pages [& body]
+  `(binding [*all-pages* true]
+    ~@body))

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -6,6 +6,7 @@
   (:import java.net.URLEncoder))
 
 (def ^:dynamic url "https://api.github.com/")
+(def ^:dynamic *all-pages* false)
 (def ^:dynamic defaults {})
 
 (defn query-map
@@ -82,31 +83,12 @@
   [end-point positional]
   (str url (apply format end-point (map #(URLEncoder/encode (str %) "UTF-8") positional))))
 
-(defn make-request [method end-point positional
-                    {:strs [auth throw_exceptions follow_redirects accept
-                            oauth_token etag if_modified_since user_agent]
-                     :or {follow_redirects true throw_exceptions false}
-                     :as query}]
-  (let [req (merge-with merge
-                        {:url (format-url end-point positional)
-                         :basic-auth auth
-                         :throw-exceptions throw_exceptions
-                         :follow-redirects follow_redirects
-                         :method method}
-                        (when accept
-                          {:headers {"Accept" accept}})
-                        (when oauth_token
-                          {:headers {"Authorization" (str "token " oauth_token)}})
-                        (when etag
-                          {:headers {"if-None-Match" etag}})
-                        (when user_agent
-                          {:headers {"User-Agent" user_agent}})
-                        (when if_modified_since
-                          {:headers {"if-Modified-Since" if_modified_since}}))
-        proper-query (dissoc query "auth" "oauth_token" "all_pages" "accept" "user_agent")
+(defn make-request [method end-point positional query]
+  (let [req {:url (format-url end-point positional)
+             :method method}
         req (if (#{:post :put :delete} method)
-              (assoc req :body (json/generate-string (or (proper-query "raw") proper-query)))
-              (assoc req :query-params proper-query))]
+              (assoc req :body (json/generate-string (or (query "raw") query)))
+              (assoc req :query-params query))]
     req))
 
 (defn api-call
@@ -114,7 +96,7 @@
   ([method end-point positional] (api-call method end-point positional nil))
   ([method end-point positional query]
      (let [query (query-map query)
-           all-pages? (query "all_pages")
+           all-pages? (*all-pages*)
            req (make-request method end-point positional query)
            exec-request-one (fn exec-request-one [req]
                               (safe-parse (http/request req)))
@@ -127,11 +109,10 @@
        (exec-request req))))
 
 (defn raw-api-call
-  ([method end-point] (raw-api-call method end-point nil nil))
-  ([method end-point positional] (raw-api-call method end-point positional nil))
+  ([method end-point] (raw-api-call method end-point nil nil nil))
+  ([method end-point positional] (raw-api-call method end-point positional nil nil))
   ([method end-point positional query]
      (let [query (query-map query)
-           all-pages? (query "all_pages")
            req (make-request method end-point positional query)]
        (http/request req))))
 

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -2,12 +2,6 @@
   (:use clojure.test)
   (:require [tentacles.core :as core]))
 
-(deftest request-contains-user-agent
-  (let [request (core/make-request :get "test" nil {"user_agent" "Mozilla"})]
-    (do (is (empty?    (:query-params request)))
-      (is (contains? (:headers request) "User-Agent"))
-      (is (= (get (:headers request) "User-Agent") "Mozilla")))))
-
 (deftest hitting-rate-limit-is-propagated
   (is (= (:status (core/safe-parse {:status 403}))
          403)))


### PR DESCRIPTION
Not suggesting this is ready to be merged yet, but I'm interested in your opinion if you have a chance to take a look. Am I on the right track? For now I removed the broken test since it doesn't really make sense anymore, but of course more tests should be added. Also I should probably add a `with-all-pages` macro so the user doesn't need to modify `*all-pages*` directly.