### PR TITLE
protect against empty contents

### DIFF
--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -424,7 +424,7 @@
        (if-let [^String encoded (get-in res path)]
          (let [trimmed (.replace encoded "\n" "")
                raw (.getBytes trimmed "UTF-8")
-               decoded (b64/decode raw)
+               decoded (if (seq raw) (b64/decode raw) (byte-array))
                done (if str? (String. decoded "UTF-8") decoded)]
            (assoc-in res path done))
          res)


### PR DESCRIPTION
Fetching the content of an empty file through the API result into out of bounds exception:

```
java.lang.ArrayIndexOutOfBoundsException: -1
    at clojure.data.codec.base64$pad_length.invokePrim(base64.clj:53)
    at clojure.data.codec.base64$decode.invokePrim(base64.clj:146)
    at clojure.data.codec.base64$decode.invoke(base64.clj:144)
    at tentacles.repos$decode_b64.invoke(repos.clj:417)
    at tentacles.repos$decode_b64.invoke(repos.clj:422)
    at tentacles.repos$contents.invoke(repos.clj:442)
```
