### PR TITLE
Call query-map later, use keywords longer

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -83,29 +83,30 @@
   (str url (apply format end-point (map #(URLEncoder/encode (str %) "UTF-8") positional))))
 
 (defn make-request [method end-point positional
-                    {:strs [auth throw_exceptions follow_redirects accept
-                            oauth_token etag if_modified_since user_agent]
-                     :or {follow_redirects true throw_exceptions false}
+                    {:keys [auth throw-exceptions follow-redirects accept
+                            oauth-token etag if-modified-since user-agent]
+                     :or {follow-redirects true throw-exceptions false}
                      :as query}]
   (let [req (merge-with merge
                         {:url (format-url end-point positional)
                          :basic-auth auth
-                         :throw-exceptions throw_exceptions
-                         :follow-redirects follow_redirects
+                         :throw-exceptions throw-exceptions
+                         :follow-redirects follow-redirects
                          :method method}
                         (when accept
                           {:headers {"Accept" accept}})
-                        (when oauth_token
-                          {:headers {"Authorization" (str "token " oauth_token)}})
+                        (when oauth-token
+                          {:headers {"Authorization" (str "token " oauth-token)}})
                         (when etag
                           {:headers {"if-None-Match" etag}})
-                        (when user_agent
-                          {:headers {"User-Agent" user_agent}})
-                        (when if_modified_since
-                          {:headers {"if-Modified-Since" if_modified_since}}))
-        proper-query (dissoc query "auth" "oauth_token" "all_pages" "accept" "user_agent")
+                        (when user-agent
+                          {:headers {"User-Agent" user-agent}})
+                        (when if-modified-since
+                          {:headers {"if-Modified-Since" if-modified-since}}))
+        raw-query (:raw query)
+        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent))
         req (if (#{:post :put :delete} method)
-              (assoc req :body (json/generate-string (or (proper-query "raw") proper-query)))
+              (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]
     req))
 
@@ -113,8 +114,8 @@
   ([method end-point] (api-call method end-point nil nil))
   ([method end-point positional] (api-call method end-point positional nil))
   ([method end-point positional query]
-     (let [query (query-map query)
-           all-pages? (query "all_pages")
+     (let [query (or query {})
+           all-pages? (query :all-pages)
            req (make-request method end-point positional query)
            exec-request-one (fn exec-request-one [req]
                               (safe-parse (http/request req)))
@@ -130,8 +131,8 @@
   ([method end-point] (raw-api-call method end-point nil nil))
   ([method end-point positional] (raw-api-call method end-point positional nil))
   ([method end-point positional query]
-     (let [query (query-map query)
-           all-pages? (query "all_pages")
+     (let [query (or query {})
+           all-pages? (query :all-pages)
            req (make-request method end-point positional query)]
        (http/request req))))
 

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -3,7 +3,7 @@
   (:require [tentacles.core :as core]))
 
 (deftest request-contains-user-agent
-  (let [request (core/make-request :get "test" nil {"user_agent" "Mozilla"})]
+  (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"})]
     (do (is (empty?    (:query-params request)))
       (is (contains? (:headers request) "User-Agent"))
       (is (= (get (:headers request) "User-Agent") "Mozilla")))))


### PR DESCRIPTION
Hello! Currently `make-request` takes a map whose keys are strings. Seeing as it's manipulating this map in various ways, I thought it'd be nicer to keep the keys as kebab-case keywords for as long as possible, and only turn it into underscore-case strings when absolutely necessary.

What do you think?
