### PR TITLE
Repo statistics API

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -50,6 +50,8 @@
    as json. Otherwise, parse and return the body if json, or return the body if raw."
   [{:keys [headers status body] :as resp}]
   (cond
+   (= 202 status)
+   ::accepted
    (= 304 status)
    ::not-modified
    (#{400 401 204 422 403 404 500} status)

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -550,3 +550,30 @@
   "Deletes a release."
   [user repo id & [options]]
   (api-call :delete "repos/%s/%s/releases/%s" [user repo id] options))
+
+;; ## Statistics API
+
+(defn contributor-statistics
+  "List additions, deletions, and commit counts per contributor"
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/stats/contributors" [user repo] options))
+
+(defn commit-activity
+  "List weekly commit activiy for the past year"
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/stats/commit_activity" [user repo] options))
+
+(defn code-frequency
+  "List weekly additions and deletions"
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/stats/code_frequency" [user repo] options))
+
+(defn participation
+  "List weekly commit count grouped by the owner and all other users"
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/stats/participation" [user repo] options))
+
+(defn punch-card
+  "List commit count per hour in the day"
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/stats/punch_card" [user repo] options))


### PR DESCRIPTION
Adds support the repo statistics endpoints: https://developer.github.com/v3/repos/statistics/

These endpoints differ from most of the GitHub API since they can return a 202 Accepted status when the results are not readily available. A 202 indicates that the statistics will be computed and be available at some point later, usually within a few seconds.

It follows the example of how 304 responses are handled and returns a keyword in the case of a 202. This worked well for my purposes of adding some polling logic on top of the call, but I'm open to other ways of handling it. Some polling logic could be built into tentacles, but I'm not sure if you it to take on that responsibility.