### PR TITLE
Add support for two-factor authentication

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -85,7 +85,8 @@
 
 (defn make-request [method end-point positional
                     {:keys [auth throw-exceptions follow-redirects accept
-                            oauth-token etag if-modified-since user-agent]
+                            oauth-token etag if-modified-since user-agent
+                            otp]
                      :or {follow-redirects true throw-exceptions false}
                      :as query}]
   (let [req (merge-with merge
@@ -102,10 +103,12 @@
                           {:headers {"if-None-Match" etag}})
                         (when user-agent
                           {:headers {"User-Agent" user-agent}})
+                        (when otp
+                          {:headers {"X-GitHub-OTP" otp}})
                         (when if-modified-since
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
-        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent))
+        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
         req (if (#{:post :put :delete} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -125,17 +125,17 @@
 (defn team-member?
   "Get a specific team member."
   [id user options]
-  (no-content? (api-call :get "teams/%s/members/%s" [id user] options)))
+  (no-content? (api-call :get "teams/%s/memberships/%s" [id user] options)))
 
 (defn add-team-member
   "Add a team member."
   [id user options]
-  (no-content? (api-call :put "teams/%s/members/%s" [id user] options)))
+  (no-content? (api-call :put "teams/%s/memberships/%s" [id user] options)))
 
 (defn delete-team-member
   "Remove a team member."
   [id user options]
-  (no-content? (api-call :delete "teams/%s/members/%s" [id user] options)))
+  (no-content? (api-call :delete "teams/%s/memberships/%s" [id user] options)))
 
 (defn list-team-repos
   "List the team repositories."


### PR DESCRIPTION
This adds support for an :otp key in query parameters in order to use two-factor authentication.

```
board.core=> (t/make-request "post" "authorizations" nil (#'g/create-query-opts "foo:bar" ["me:admin"] "049902"))
{:query-params {"note_url" "https://github.com/grepory/board", "note" "Board GitHub integration", "scopes" ["me:admin"]}, :headers {"X-GitHub-OTP" "049902"}, :url "https://api.github.com/authorizations", :basic-auth "foo:bar", :throw-exceptions false, :follow-redirects true, :method "post"}
```

```
board.core=> (o/create-auth (#'g/create-query-opts "grepory:password" ["admin:org"] "000000"))
{:scopes ["admin:org"], :note "Board GitHub integration", :updated_at "2015-04-27T21:47:10Z", :token_last_eight "snip", :token "snip", :id 17515472, :app {:name "Board GitHub integration (API)", :url "https://github.com/grepory/board", :client_id "00000000000000000000"}, :url "https://api.github.com/authorizations/17515472", :note_url "https://github.com/grepory/board", :fingerprint nil, :created_at "2015-04-27T21:47:10Z", :hashed_token "snip"}
```

I couldn't decide what to use for the key, so I left it otp, as referenced in the GitHub header in which the one-time password is passed.