### PR TITLE
Add calls to retrieve pull/issue comments for a repo

### DIFF
--- a/src/tentacles/issues.clj
+++ b/src/tentacles/issues.clj
@@ -96,6 +96,11 @@
 
 ;; ## Issue Comments API
 
+(defn repo-issue-comments
+  "List issue comments in a repository."
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/issues/comments" [user repo] options))
+
 (defn issue-comments
   "List comments on an issue."
   [user repo id & [options]]

--- a/src/tentacles/pulls.clj
+++ b/src/tentacles/pulls.clj
@@ -67,6 +67,11 @@
 
 ;; ## Pull Request Comment API
 
+(defn repo-comments
+  "List pull request comments in a repository."
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/pulls/comments" [user repo] options))
+
 (defn comments
   "List comments on a pull request."
   [user repo id & [options]]


### PR DESCRIPTION
Implements: 

https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository
https://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository

Not to be confused with https://developer.github.com/v3/repos/comments/ which just grabs the commit comments for the repo, as opposed to the issue/pull comments.