### PR TITLE
Edit commands now use PATCH

### DIFF
--- a/src/tentacles/gists.clj
+++ b/src/tentacles/gists.clj
@@ -74,7 +74,7 @@
                      the name of the file. If one of the file keys in
                      the map is associated with 'nil', it'll be deleted."
   [id & [options]]
-  (api-call :post "gists/%s" [id] options))
+  (api-call :patch "gists/%s" [id] options))
 
 (defn star-gist
   "Star a gist."
@@ -123,7 +123,7 @@
 (defn edit-comment
   "Edit a comment."
   [comment-id body options]
-  (api-call :post "gists/comments/%s" [comment-id] (assoc options :body body)))
+  (api-call :patch "gists/comments/%s" [comment-id] (assoc options :body body)))
 
 (defn delete-comment
   "Delete a comment."

--- a/src/tentacles/issues.clj
+++ b/src/tentacles/issues.clj
@@ -92,7 +92,7 @@
      title     -- Title of the issue.
      body      -- The body text of the issue."
   [user repo id options]
-  (api-call :post "repos/%s/%s/issues/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/issues/%s" [user repo id] options))
 
 ;; ## Issue Comments API
 
@@ -120,7 +120,7 @@
 (defn edit-comment
   "Edit a comment."
   [user repo comment-id body options]
-  (api-call :post "repos/%s/%s/issues/comments/%s"
+  (api-call :patch "repos/%s/%s/issues/comments/%s"
             [user repo comment-id] (assoc options :body body)))
 
 (defn delete-comment
@@ -173,7 +173,7 @@
 (defn edit-label
   "Edit a label."
   [user repo id name color options]
-  (api-call :post "repos/%s/%s/labels/%s"
+  (api-call :patch "repos/%s/%s/labels/%s"
             [user repo id] (assoc options :name name :color color)))
 
 (defn delete-label
@@ -242,7 +242,7 @@
      description -- a description string.
      due-on      -- String ISO 8601 timestamp"
   [user repo id title options]
-  (api-call :post "repos/%s/%s/milestones/%s"
+  (api-call :patch "repos/%s/%s/milestones/%s"
             [user repo id] (assoc options :title title)))
 
 (defn delete-milestone

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -34,7 +34,7 @@
       location      -- Organization location.
       name          -- Name of the organization."
   [org options]
-  (api-call :post "orgs/%s" [org] options))
+  (api-call :patch "orgs/%s" [org] options))
 
 ;; ## Org Members API
 
@@ -110,7 +110,7 @@
                      push: team can push and pull but not admin.
                      admin: team can push, pull, and admin."
   [id options]
-  (api-call :post "teams/%s" [id] options))
+  (api-call :patch "teams/%s" [id] options))
 
 (defn delete-team
   "Delete a team."

--- a/src/tentacles/pulls.clj
+++ b/src/tentacles/pulls.clj
@@ -41,7 +41,7 @@
       body  -- a new body.
       state -- open or closed."
   [user repo id options]
-  (api-call :post "repos/%s/%s/pulls/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/pulls/%s" [user repo id] options))
 
 (defn commits
   "List the commits on a pull request."
@@ -97,7 +97,7 @@
 (defn edit-comment
   "Edit a comment on a pull request."
   [user repo id body options]
-  (api-call :post "repos/%s/%s/pulls/comments/%s" [user repo id]
+  (api-call :patch "repos/%s/%s/pulls/comments/%s" [user repo id]
             (assoc options :body body)))
 
 (defn delete-comment

--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -79,7 +79,7 @@
       has-wiki      -- true, false.
       has-downloads -- true, false."
   [user repo options]
-  (api-call :post "repos/%s/%s"
+  (api-call :patch "repos/%s/%s"
             [user repo]
             (if (:name options)
               options
@@ -279,14 +279,6 @@
   (api-call :post "repos/%s/%s/keys" [user repo]
             (assoc options :title title :key key)))
 
-(defn edit-key
-  "Edit a deploy key.
-   Options are:
-      title -- New title.
-      key   -- New key."
-  [user repo id options]
-  (api-call :post "repos/%s/%s/keys/%s" [user repo id] options))
-
 (defn delete-key
   "Delete a deploy key."
   [user repo id options]
@@ -380,7 +372,7 @@
       active        -- true or false; determines if the hook is actually
                        triggered on pushes."
   [user repo id options]
-  (api-call :post "repos/%s/%s/hooks/%s" [user repo id] options))
+  (api-call :patch "repos/%s/%s/hooks/%s" [user repo id] options))
 
 (defn test-hook
   "Test a hook."

--- a/src/tentacles/users.clj
+++ b/src/tentacles/users.clj
@@ -28,7 +28,7 @@
       hireable -- Looking for a job?
       bio      -- User's biography."
   [options]
-  (api-call :post "user" nil options))
+  (api-call :patch "user" nil options))
 
 (defn emails
   "List the authenticated user's emails."
@@ -101,14 +101,6 @@
   "Create a new public key."
   [title key options]
   (api-call :post "user/keys" nil (assoc options :title title :key key)))
-
-(defn edit-key
-  "Edit an existing public key.
-   Options are:
-      title -- New title.
-      key   -- New key."
-  [id options]
-  (api-call :post "user/keys/%s" [id] options))
 
 (defn delete-key
   "Delete a public key."


### PR DESCRIPTION
Additionally, edit commands for keys have been removed as they don't
work anymore on Github's latest API. You have to delete and read a key
to change it nowadays.