### PR TITLE
endpoint can set with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Here are some lovely [Marginalia docs](http://raynes.github.com/tentacles). I al
 
 If you run into something that isn't documented well or you don't understand, look for the API call on the Github API [docs](http://developer.github.com/v3/). If you feel like it, please submit a pull request with improved documentation. Let's make this the most impressive Github API library around!
 
+For Working with Github Enterprise use `:url "http://<hostname>/api/v3/"`
+
 ## Hacking
 
 ### Running the tests

--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -80,17 +80,19 @@
 (defn format-url
   "Creates a URL out of end-point and positional. Called URLEncoder/encode on
    the elements of positional and then formats them in."
-  [end-point positional]
-  (str url (apply format end-point (map url/url-encode positional))))
+  [host end-point positional]
+  (str host (apply format end-point (map url/url-encode positional))))
+
 
 (defn make-request [method end-point positional
                     {:keys [auth throw-exceptions follow-redirects accept
                             oauth-token etag if-modified-since user-agent
-                            otp]
-                     :or {follow-redirects true throw-exceptions false}
+                            otp url]
+                     :or {follow-redirects true throw-exceptions false
+                          url url}
                      :as query}]
   (let [req (merge-with merge
-                        {:url (format-url end-point positional)
+                        {:url (format-url url end-point positional)
                          :basic-auth auth
                          :throw-exceptions throw-exceptions
                          :follow-redirects follow-redirects

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -8,6 +8,19 @@
       (is (contains? (:headers request) "User-Agent"))
       (is (= (get (:headers request) "User-Agent") "Mozilla")))))
 
+(deftest settable-enterprise-end-point-to-request
+  (let [end-point "https://hostname/api/v3/"]
+    (testing "When default url"
+      (let [request (core/make-request :get "test" nil nil)]
+        (is (= (:url request) "https://api.github.com/test"))))
+    (testing "When set url with option"
+      (let [request (core/make-request :get "test" nil {:url end-point})]
+        (is (= (:url request) (str end-point "test")))))
+    (testing "When set url with binding macro"
+      (binding [core/url end-point]
+        (let [request (core/make-request :get "test" nil nil)]
+          (is (= (:url request) (str end-point "test"))))))))
+
 (deftest hitting-rate-limit-is-propagated
   (is (= (:status (core/safe-parse {:status 403}))
          403)))


### PR DESCRIPTION
This patch is for working with GHE.

User can pass GHE endpoint with option. 
Additionally, This patch has compatible with before version. 
So, We can set `url` dynamically with `binding` macro same as be before.