### PR TITLE
Allow defaults to be added as request headers

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -8,10 +8,10 @@
 (def ^:dynamic defaults {})
 
 (defn query-map
-  "Merge defaults, turn keywords into strings, and replace hyphens with underscores."
+  "Turn keywords into strings, and replace hyphens with underscores."
   [entries]
   (into {}
-        (for [[k v] (concat defaults entries)]
+        (for [[k v] entries]
           [(.replace (name k) "-" "_") v])))
 
 (defn parse-json
@@ -83,13 +83,13 @@
   [end-point positional]
   (str url (apply format end-point (map url/url-encode positional))))
 
-(defn make-request [method end-point positional
-                    {:keys [auth throw-exceptions follow-redirects accept
-                            oauth-token etag if-modified-since user-agent
-                            otp]
-                     :or {follow-redirects true throw-exceptions false}
-                     :as query}]
-  (let [req (merge-with merge
+(defn make-request [method end-point positional query]
+  (let [{:keys [auth throw-exceptions follow-redirects accept
+                oauth-token etag if-modified-since user-agent
+                otp]
+         :or {follow-redirects true throw-exceptions false}
+         :as query} (merge defaults query)
+        req (merge-with merge
                         {:url (format-url end-point positional)
                          :basic-auth auth
                          :throw-exceptions throw-exceptions

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -4,9 +4,26 @@
 
 (deftest request-contains-user-agent
   (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"})]
-    (do (is (empty?    (:query-params request)))
+    (do
+      (is (empty?    (:query-params request)))
       (is (contains? (:headers request) "User-Agent"))
       (is (= (get (:headers request) "User-Agent") "Mozilla")))))
+
+(deftest request-contains-user-agent-from-defaults
+  (core/with-defaults {:user-agent "Mozilla"}
+    (let [request (core/make-request :get "test" nil {})]
+      (do
+        (is (empty?    (:query-params request)))
+        (is (contains? (:headers request) "User-Agent"))
+        (is (= (get (:headers request) "User-Agent") "Mozilla"))))))
+
+(deftest adhoc-options-override-defaults
+  (core/with-defaults {:user-agent "default"}
+    (let [request (core/make-request :get "test" nil {:user-agent "adhoc"})]
+      (do
+        (is (empty?    (:query-params request)))
+        (is (contains? (:headers request) "User-Agent"))
+        (is (= (get (:headers request) "User-Agent") "adhoc"))))))
 
 (deftest hitting-rate-limit-is-propagated
   (is (= (:status (core/safe-parse {:status 403}))


### PR DESCRIPTION
This PR ensures that defaults are merged into a query _before_ deciding which headers to add to a request. See #85 for more details.

I've tried to avoid changing too much here. Feel free to recommend any change to this commit (no matter how small) and I will amend.

Thanks!