### PR TITLE
PATCH also needs JSON data

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -109,7 +109,7 @@
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
         proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
-        req (if (#{:post :put :delete} method)
+        req (if (#{:patch :post :put :delete} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]
     req))


### PR DESCRIPTION
Following change in #82 , this broke at least the gists/edit-gist function. Github API would return a 400 with :body {:message "Problems parsing JSON", :documentation_url "https://developer.github.com/v3/gists/#edit-a-gist"}.

With this change I was successfully able to edit gists content again :-)