### PR TITLE
Bump clj-http

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "1.0.1"]
+                 [clj-http "2.0.1"]
                  [cheshire "5.4.0"]
                  [com.cemerick/url "0.1.1"]
                  [org.clojure/data.codec "0.1.0"]


### PR DESCRIPTION
clj-http dependencies were updated for compatibility with clojure 1.8. Bumping clj-http so tentacles can be used with clojure 1.8
