### PR TITLE
add 2 GET methods from notifications GitHub API & bump clj-http to 2.1.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "1.0.1"]
+                 [clj-http "2.1.0"]
                  [cheshire "5.4.0"]
                  [com.cemerick/url "0.1.1"]
                  [org.clojure/data.codec "0.1.0"]

--- a/src/tentacles/notifications.clj
+++ b/src/tentacles/notifications.clj
@@ -1,0 +1,21 @@
+(ns tentacles.notifications
+  "Implements ght Github Notification API: https://developer.github.com/v3/activity/notifications/"
+  (:use [tentacles.core :only [api-call]]))
+
+(defn my-notifications
+  "List all notifications for the current user, grouped by repository.
+   Options are:
+   all            -- show notifications marked as read. Defaults to false.
+   participating  -- shows notifications in which the user is directly participating or mentioned. Defaults to false.
+   since          -- string ISO 8601 timestamp."
+  [& [options]]
+  (api-call :get "notifications" nil options))
+
+(defn repo-notifications
+  "List all notifications for the current user and repository.
+  Options are:
+   all            -- show notifications marked as read. Defaults to false.
+   participating  -- show notifications in which the user is directly participating or mentioned. Defaults to false.
+   since          -- string ISO 8601 timestamp."
+  [user repo & [options]]
+  (api-call :get "repos/%s/%s/notifications" [user repo] options))


### PR DESCRIPTION
add 2 GET methods from here https://developer.github.com/v3/activity/notifications/ and bump clj-http to 2.1.0
