### PR TITLE
PATCH requests json encode their request bodies

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -109,7 +109,7 @@
                           {:headers {"if-Modified-Since" if-modified-since}}))
         raw-query (:raw query)
         proper-query (query-map (dissoc query :auth :oauth-token :all-pages :accept :user-agent :otp))
-        req (if (#{:post :put :delete} method)
+        req (if (#{:post :put :delete :patch} method)
               (assoc req :body (json/generate-string (or raw-query proper-query)))
               (assoc req :query-params proper-query))]
     req))

--- a/test/tentacles/core_test.clj
+++ b/test/tentacles/core_test.clj
@@ -2,6 +2,10 @@
   (:use clojure.test)
   (:require [tentacles.core :as core]))
 
+(deftest patch-requests-encode-json-body
+  (let [request (core/make-request :patch "foo" nil {:bar "baz"})]
+    (is (= (:body request) "{\"bar\":\"baz\"}"))))
+
 (deftest request-contains-user-agent
   (let [request (core/make-request :get "test" nil {:user-agent "Mozilla"})]
     (do


### PR DESCRIPTION
Github throws 400 errors for `PATCH` requests that have content currently. Editing a hook is one example of this:

https://developer.github.com/v3/repos/hooks/#edit-a-hook
