### PR TITLE
Org Hooks

### DIFF
--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -156,3 +156,47 @@
   "Remove a repo from a team."
   [id user repo options]
   (no-content? (api-call :delete "teams/%s/repos/%s/%s" [id user repo] options)))
+
+;; ## Org Hooks API
+
+(defn hooks
+  "List the hooks on an organization."
+  [org options]
+  (api-call :get "orgs/%s/hooks" [org] options))
+
+(defn specific-hook
+  "Get a specific hook."
+  [org id options]
+  (api-call :get "orgs/%s/hooks/%s" [org id] options))
+
+(defn create-hook
+  "Create a hook.
+   Options are:
+      events -- A sequence of event strings. Only 'push' by default.
+      active -- true or false; determines if the hook is actually triggered
+                on pushes."
+  [org config options]
+  (api-call :post "orgs/%s/hooks" [org]
+            (assoc options
+                   :name "web"
+                   :config config)))
+
+(defn edit-hook
+  "Edit an existing hook.
+   Options are:
+      config        -- Modified config.
+      events        -- A sequence of event strings. Replaces the events.
+      active        -- true or false; determines if the hook is actually
+                       triggered on pushes."
+  [org id options]
+  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :name "web")))
+
+(defn ping-hook
+  "Ping a hook."
+  [org id options]
+  (no-content? (api-call :post "orgs/%s/hooks/%s/pings" [org id] options)))
+
+(defn delete-hook
+  "Delete a hook."
+  [org id options]
+  (no-content? (api-call :delete "orgs/%s/hooks/%s" [org id] options)))

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -188,8 +188,8 @@
       events        -- A sequence of event strings. Replaces the events.
       active        -- true or false; determines if the hook is actually
                        triggered on pushes."
-  [org id options]
-  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :name "web")))
+  [org id config options]
+  (api-call :patch "orgs/%s/hooks/%s" [org id] (assoc options :config config)))
 
 (defn ping-hook
   "Ping a hook."


### PR DESCRIPTION
Implements [org hooks](https://developer.github.com/v3/orgs/hooks/), adopted from the repo hooks api. Tested all with my own github creds (oauth token).

Note that the docs only allow org hooks with the name "web", see [here](https://developer.github.com/v3/orgs/hooks/#parameters)