### PR TITLE
Add options to releases so that we can auth with github

### DIFF
--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -558,8 +558,10 @@
 
 (defn releases
   "List releases for a repository."
-  [user repo]
-  (api-call :get "repos/%s/%s/releases" [user repo]))
+  ([user repo]
+   (releases user repo {}))
+  ([user repo options]
+   (api-call :get "repos/%s/%s/releases" [user repo] options)))
 
 (defn specific-release
   "Gets a specific release."


### PR DESCRIPTION
- Add "options" to "repos/releases" so that auth can be used when calling the API
- Add a different function signature so that the current API isn't broken.