### PR TITLE
Updated dependency versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject tentacles "0.5.1"
+(defproject tentacles "0.5.2-SNAPSHOT"
   :description "A library for working with the Github API."
   :url "https://github.com/Raynes/tentacles"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "1.0.1"]
-                 [cheshire "5.4.0"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [clj-http "3.1.0"]
+                 [cheshire "5.6.3"]
                  [com.cemerick/url "0.1.1"]
                  [org.clojure/data.codec "0.1.0"]
-                 [environ "1.0.0"]])
+                 [environ "1.1.0"]])


### PR DESCRIPTION
Updated dependency versions to the latest & greatest, which resolved a compilation error I was receiving from clj-http (incompatibility between clj-http v1.x and Clojure v1.8, I believe?).

Tests seem to pass:
```

Testing tentacles.core-test

Testing tentacles.gists-test

Testing tentacles.search-test

Ran 10 tests containing 17 assertions.
0 failures, 0 errors.
```