### PR TITLE
Added support for searching for releases by tag

### DIFF
--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -566,6 +566,10 @@
   [user repo id & [options]]
   (api-call :get "repos/%s/%s/releases/%s" [user repo id] options))
 
+(defn specific-release-by-tag
+  "Gets a specific release by tag."
+  [user repo tag & [options]]
+  (api-call :get "repos/%s/%s/releases/tags/%s" [user repo tag] options))
 
 (defn create-release
   "Creates a release.


### PR DESCRIPTION
GitHub API:

https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name

```clj
(defn get-by-tag
  (repos/specific-release-by-tag "v0.0.1"))
```