### PR TITLE
Update to new watch endpoint

### DIFF
--- a/src/tentacles/repos.clj
+++ b/src/tentacles/repos.clj
@@ -294,7 +294,7 @@
 (defn watching
   "List all the repositories that a user is watching."
   [user & [options]]
-  (api-call :get "users/%s/watched" [user] options))
+  (api-call :get "users/%s/subscriptions" [user] options))
 
 (defn watching?
   "Check if you are watching a repository."


### PR DESCRIPTION
As per this [api doc page](https://developer.github.com/v3/activity/watching/#list-repositories-being-watched).
I'm not sure if other watch related endpoints have changed also.