### PR TITLE
Add support for X-Ratelimit-Reset header

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -33,12 +33,13 @@
 (defn extract-useful-meta
   [h]
   (let [{:strs [etag last-modified x-ratelimit-limit x-ratelimit-remaining
-                x-poll-interval]}
+                x-poll-interval x-ratelimit-reset]}
         h]
     {:etag etag :last-modified last-modified
      :call-limit (when x-ratelimit-limit (Long/parseLong x-ratelimit-limit))
      :call-remaining (when x-ratelimit-remaining (Long/parseLong x-ratelimit-remaining))
-     :poll-interval (when x-poll-interval (Long/parseLong x-poll-interval))}))
+     :poll-interval (when x-poll-interval (Long/parseLong x-poll-interval))
+     :call-limit-reset (when x-ratelimit-reset (Long/parseLong x-ratelimit-reset))}))
 
 (defn api-meta
   [obj]


### PR DESCRIPTION
Github use a `X-Ratelimit-Reset` header now.

This is epoc time when your current limit resets. I'm not sure if `x-poll-interval` is still in use but I left it as it may just not on the calls I've made. Or others using an older version on Github Enterprise may still use it.

Thanks, let me know if you have any questions.