### PR TITLE
Add `orgs-memberships` function to list all organizational memberships for the current user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Dependencies Status](https://jarkeeper.com/Raynes/tentacles/status.svg)](https://jarkeeper.com/Raynes/tentacles)
 
+NOT USED ANYMORE.
+
 # An octocat is nothing without her tentacles
 
 Tentacles is a Clojure library for working with the Github v3 API. It supports the entire Github API.

--- a/src/tentacles/orgs.clj
+++ b/src/tentacles/orgs.clj
@@ -15,6 +15,12 @@
   [options]
   (api-call :get "user/orgs" nil options))
 
+(defn orgs-memberships
+  "List all the organizational memberships including for the currently
+   authenticated user including `state` and `role` of the user."
+  [options]
+  (api-call :get "user/memberships/orgs" nil options))
+
 (defn specific-org
   "Get a specific organization."
   [org & [options]]


### PR DESCRIPTION
This is useful to not only get all user's organizations but also
his role in each of those organizations.

See https://developer.github.com/v3/orgs/members/#list-your-organization-memberships.